### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## [0.3.0] - 2026-03-17
+
+### Added
+- polish branch-aware release channels
+
+### Changed
+- reconcile 0.2.0 release metadata
+
+### Contributors
+Thanks to our contributors for this release:
+- @iamgp (2 commits)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,28 +1,49 @@
-[package]
-name = "pyrls"
-version = "0.2.0"
-edition = "2024"
-description = "A single-binary release automation tool for Python projects"
-license = "MIT"
-repository = "https://github.com/iamgp/pyrls"
-homepage = "https://github.com/iamgp/pyrls"
-readme = "README.md"
-keywords = ["python", "release", "changelog", "pypi", "conventional-commits"]
-categories = ["command-line-utilities", "development-tools"]
-
 [dependencies]
 anyhow = "1.0"
-clap = { version = "4.5", features = ["derive"] }
 console = "0.15"
 git2 = "0.20"
 indicatif = "0.17"
-serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.20"
 thiserror = "2.0"
 toml = "0.9"
-openssl = { version = "0.10", features = ["vendored"] }
-ureq = { version = "2.12", features = ["json"] }
+
+[dependencies.clap]
+features = ["derive"]
+version = "4.5"
+
+[dependencies.openssl]
+features = ["vendored"]
+version = "0.10"
+
+[dependencies.serde]
+features = ["derive"]
+version = "1.0"
+
+[dependencies.ureq]
+features = ["json"]
+version = "2.12"
 
 [dev-dependencies]
 mockito = "1.7"
+
+[package]
+categories = [
+    "command-line-utilities",
+    "development-tools",
+]
+description = "A single-binary release automation tool for Python projects"
+edition = "2024"
+homepage = "https://github.com/iamgp/pyrls"
+keywords = [
+    "python",
+    "release",
+    "changelog",
+    "pypi",
+    "conventional-commits",
+]
+license = "MIT"
+name = "pyrls"
+readme = "README.md"
+repository = "https://github.com/iamgp/pyrls"
+version = "0.3.0"


### PR DESCRIPTION
## Release summary

## [0.3.0] - 2026-03-17

### Added
- polish branch-aware release channels

### Changed
- reconcile 0.2.0 release metadata

### Contributors
Thanks to our contributors for this release:
- @iamgp (2 commits)

## Maintainer checklist
- [ ] Review version bump
- [ ] Review changelog
- [ ] Merge to cut the release