### PR TITLE
fix: use the published ReleaseX action

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install relx
-        uses: ReleaseX/action@v1
+        uses: iamgp/ReleaseX@v1
         with:
           command: status
           args: --help > /dev/null


### PR DESCRIPTION
## Summary
- fix the beta autorelease workflow to use `iamgp/ReleaseX@v1` instead of the invalid `ReleaseX/action@v1` reference
- keep the workflow using the published binary rather than building relx from source

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/autorelease.yml"); puts "yaml ok"'
- git diff --check