### PR TITLE
feat!: stabilise for 1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ relx supports PEP 440 pre-release versions:
 - Post-release: `1.2.0.post1`
 - Dev: `1.2.0.dev1`
 
-Pre-release and finalization support is planned via `--pre-release` and `--finalize` flags on the release commands (see the [PRD](prd.md) for roadmap details).
+Use `--pre-release` (`alpha`, `beta`, `rc`) and `--finalize` flags on the release commands to manage pre-release workflows.
 
 ## Monorepo Support
 


### PR DESCRIPTION
Updates README to reflect pre-release flags as implemented (not planned). The `feat!:` breaking change marker will trigger a major version bump from 0.x → 1.0.0.